### PR TITLE
Make implicit multiply work (i.e. spaces and tabs act as *).

### DIFF
--- a/Auxiliary/Grammars/kranc2.peg
+++ b/Auxiliary/Grammars/kranc2.peg
@@ -1,7 +1,9 @@
 skipper = \b([ \t\n\r]+|\#.*)*
 int = [0-9]+
 end = ([ \t]+|\#.*)*\r*\n
-name = [A-Za-z][A-Za-z0-9]*
+
+keywords = to
+name = (?!D|{keywords}\b)[A-Za-z][A-Za-z0-9]*
 uname = [A-Za-z][A-Za-z0-9_]*
 lower_index = ({index_symbol}|\({index_expr}(,{index_expr})*\))
 upper_index = ({index_symbol}|\({index_expr}(,{index_expr})*\))
@@ -19,10 +21,11 @@ neg = -
 value = {func}|{dtensor}|{tensor}|{number}|\( {expr} \)
 pow = {value}( \*\* {value}|)
 mulop = [*/%]
-mul = {pow}( {mulop} {pow})*
+mulimp = [ \t]*
+mul = {pow}( {mulop} {pow}|{mulimp}{pow})*
 addop = [+-]
 mexpr = {mul}( {addop} {mul})*
-expr = {neg}?{mexpr}( \? {mexpr} : {mexpr})?
+expr = {neg}?{mexpr}
 eqn = ({dtensor}|{tensor}) \= {expr}{-end}
 deqn = {dtensor} \= {expr}{-end}
 eqns = {eqn}( {eqn})*
@@ -39,7 +42,7 @@ desc = ((?!default:)[^])*
 infinity = infinity
 parlo = - {infinity}|{expr}
 parhi = {infinity}|{expr}
-parameter = name:  {name} description: {desc} default: {expr} range: {parlo} to {parhi}
+parameter = name:  {name} description: {desc} default: {expr} range: {parlo}[ \t]+to[ \t]+{parhi}
 temporaries = begin[ \t]+temporaries{-end} ( end[ \t]+temporaries\b{brk}| {tensor})*{-end}
 option = {inherit}|{use}|{disable}|{implement}
 inherit = inherit[ \t]+({uname}[ \t]*)+{-end}

--- a/Examples/SimpleWaveScriptCaKernel.kranc
+++ b/Examples/SimpleWaveScriptCaKernel.kranc
@@ -13,7 +13,7 @@ begin parameters
   name: kfac
   description: The wave number
   default: 2*PI
-  range: 0 to 10*PI
+  range: 0 to 10 PI
 end parameters
 
 begin variables
@@ -21,18 +21,18 @@ begin variables
 end variables
 
 begin calculation initial_sine_calc scheduled at initial
-  phi = amp*sin(kfac*x)
+  phi = amp sin(kfac x)
   pi = 0
 end calculation
 
 begin calculation calc_rhs scheduled at MoL_CalcRHS
   D_t phi = pi
-  D_t pi = Euc^ij*D_ij phi
+  D_t pi = Euc^ij D_ij phi
 end calculation
 
 begin calculation calc_bound_rhs scheduled at MoL_CalcRHS on boundary
   D_t phi = pi
-  D_t pi = -kfac**2*phi
+  D_t pi = -kfac**2 phi
 end calculation
 
 end thorn

--- a/Tools/CodeGen/KrancScript.m
+++ b/Tools/CodeGen/KrancScript.m
@@ -174,6 +174,7 @@ process["expr"["neg"[_],m:"mexpr"[___]]] := -process[m];
 process["mul"[pow_]] := process[pow];
 process["mul"[]] := 1;
 process["mul"[cs___, a_, "mulop"["*"], b_]] := process["mul"[cs,a]] * process[b];
+process["mul"[cs___, a_, "mulimp"[___], b_]] := process["mul"[cs,a]] * process[b];
 process["mul"[cs___, a_, "mulop"["/"], b_]] := process["mul"[cs,a]] / process[b];
 
 process["pow"[a_,b_]] := process[a]^process[b];
@@ -196,7 +197,7 @@ process["number"[num_],"rightenc"[sym_]] := num <> sym;
 process["infinity"[_]] := "*";
 
 processRange[value_,minOrMax_,paramName_] :=
-  If[StringQ[value] && value == "*",value,
+  If[StringQ[value] && value === "*",value,
     Module[{tmp},
       tmp = N[value];
       If[NumberQ[tmp],1,ThrowError[minOrMax<>" value for parameter "<>paramName<>" is not a number"]];


### PR DESCRIPTION
This change enables implicit multiplication using spaces and tabs (i.e. not new lines or carriage returns). Thus, if you have a long equation and you wish to have it span multiple lines, you should use an explicit *, e.g.

  foo = 3 a b d*
    e f g

Another side-effect of this change is it makes "to" a keyword (i.e. you can't have a variable named "to"). The reason is that this makes the parameter range impossible to parse. Alternatively, we could use "->" instead of the word "to" in the range specification. While I was making "to" illegal, I also made variables starting with capital D illegal (these names are reserved for derivatives).
