### PR TITLE
CodeGenCalculation.m: make calc_every work in both EVOL and POSTSTEP

### DIFF
--- a/Tools/CodeGen/CodeGenCalculation.m
+++ b/Tools/CodeGen/CodeGenCalculation.m
@@ -531,8 +531,9 @@ DefFn[
                "\");\n"],
 
              ConditionalOnParameterTextual[
-               "cctk_iteration % " <> functionName <> "_calc_every != " <>
-               functionName <> "_calc_offset", "return;\n"],
+               "(cctk_iteration - " <> functionName <> "_calc_offset) % " <>
+               functionName <> "_calc_every != 0"
+               , "return;\n"],
   
              CheckGroupStorage[GroupsInCalculation[cleancalc, imp],
                                functionName],


### PR DESCRIPTION
for a refinement level that evaluates every rl_every the routines are
called in EVOL whenever (cctk_iteration-1) % rl_every is zero (ie the
iteration after cctk_iteration % rl_every was valid). Thus calc_offset
needs to be set to 1 and removed from the iteration number rather than
checked for as a remaineder.