### PR TITLE
Use presync

### DIFF
--- a/Auxiliary/Cactus/SourceFiles/Kranc.hh
+++ b/Auxiliary/Cactus/SourceFiles/Kranc.hh
@@ -46,6 +46,48 @@ typedef void(*Kranc_Calculation)(cGH const * restrict cctkGH,
 
 // Boundary information
 
+CCTK_ATTRIBUTE_UNUSED
+static CCTK_INT KrancBdy_SelectVarForBC(
+    const CCTK_POINTER_TO_CONST cctkGH_,
+    const CCTK_INT faces,
+    const CCTK_INT width,
+    const CCTK_INT table_handle,
+    const CCTK_STRING var_name,
+    const CCTK_STRING bc_name) {
+
+    static bool is_aliased = CCTK_IsFunctionAliased("Driver_SelectGroupForBC");
+
+    int ierr = 0;
+
+    ierr = Boundary_SelectVarForBC(cctkGH_,faces,width,table_handle,var_name,bc_name);
+
+    if(ierr == 0 && is_aliased)
+        ierr = Driver_SelectVarForBC(cctkGH_,faces,width,table_handle,var_name,bc_name);
+
+    return ierr;
+}
+
+CCTK_ATTRIBUTE_UNUSED
+static CCTK_INT KrancBdy_SelectGroupForBC(
+    const CCTK_POINTER_TO_CONST cctkGH_,
+    const CCTK_INT faces,
+    const CCTK_INT width,
+    const CCTK_INT table_handle,
+    const CCTK_STRING group_name,
+    const CCTK_STRING bc_name) {
+
+    static bool is_aliased = CCTK_IsFunctionAliased("Driver_SelectGroupForBC");
+
+    int ierr;
+
+    ierr = Boundary_SelectGroupForBC(cctkGH_,faces,width,table_handle,group_name,bc_name);
+
+    if(ierr == 0 && is_aliased)
+        ierr = Driver_SelectGroupForBC(cctkGH_,faces,width,table_handle,group_name,bc_name);
+
+    return ierr;
+}
+
 int GetBoundaryWidth(cGH const * restrict const cctkGH);
 
 void GetBoundaryInfo(cGH const * restrict cctkGH,
@@ -172,5 +214,8 @@ KRANC_WHERE static inline int isgn(CCTK_REAL x)
 }
 
 } // namespace @THORN_NAME@
+
+using @THORN_NAME@::KrancBdy_SelectVarForBC;
+using @THORN_NAME@::KrancBdy_SelectGroupForBC;
 
 #endif  // #ifndef KRANC_HH

--- a/Tools/CodeGen/CactusBoundary.m
+++ b/Tools/CodeGen/CactusBoundary.m
@@ -58,7 +58,15 @@ GetUsedFunctions[] :=
    Type      -> "CCTK_INT",
    ArgString -> "CCTK_POINTER_TO_CONST IN GH, CCTK_INT IN faces, CCTK_INT IN boundary_width, CCTK_INT IN table_handle, CCTK_STRING IN group_name, CCTK_STRING IN bc_name"},
 
+  {Name      -> "Driver_SelectGroupForBC",
+   Type      -> "CCTK_INT",
+   ArgString -> "CCTK_POINTER_TO_CONST IN GH, CCTK_INT IN faces, CCTK_INT IN boundary_width, CCTK_INT IN table_handle, CCTK_STRING IN group_name, CCTK_STRING IN bc_name"},
+
   {Name      -> "Boundary_SelectVarForBC",
+   Type      -> "CCTK_INT",
+   ArgString -> "CCTK_POINTER_TO_CONST IN GH, CCTK_INT IN faces, CCTK_INT IN boundary_width, CCTK_INT IN table_handle, CCTK_STRING IN var_name, CCTK_STRING IN bc_name"},
+
+  {Name      -> "Driver_SelectVarForBC",
    Type      -> "CCTK_INT",
    ArgString -> "CCTK_POINTER_TO_CONST IN GH, CCTK_INT IN faces, CCTK_INT IN boundary_width, CCTK_INT IN table_handle, CCTK_STRING IN var_name, CCTK_STRING IN bc_name"}
 };

--- a/Tools/CodeGen/CalculationBoundaries.m
+++ b/Tools/CodeGen/CalculationBoundaries.m
@@ -62,7 +62,7 @@ CalculationBoundariesFunction[calc_List] :=
     selectGroup[g_String] :=
       Module[{},
         {(* "table = GenericFD_BoundaryWidthTable(cctkGH);\n", *)
-         "ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, GetBoundaryWidth(cctkGH), -1 /* no table */, ",
+         "ierr = KrancBdy_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, GetBoundaryWidth(cctkGH), -1 /* no table */, ",
                  Quote[g], ",", Quote["flat"], ");\n",
         "if (ierr < 0)\n",
         "  CCTK_WARN(CCTK_WARN_ALERT, " <> Quote["Failed to register flat BC for "<>g<>"."] <> ");\n" }];

--- a/Tools/CodeGen/MoL.m
+++ b/Tools/CodeGen/MoL.m
@@ -206,7 +206,7 @@ DefFn[CreateMoLBoundariesSource[spec_] :=
      "    CCTK_EQUALS(" <> boundpar <> ", \"zero\"  ) )\n",
      "{\n",
 
-     "  ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, 1, -1,\n",
+     "  ierr = KrancBdy_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, 1, -1,\n",
      "                    \"" <> fullgroupname <> "\", " <> boundpar <> ");\n",
 
      "  if (ierr < 0)\n",
@@ -228,7 +228,7 @@ DefFn[CreateMoLBoundariesSource[spec_] :=
      "    CCTK_EQUALS(" <> boundpar <> ", \"zero\"  ) )\n",
      "{\n",
 
-     "  ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1,\n",
+     "  ierr = KrancBdy_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1,\n",
      "                    \"" <> fullgfname <> "\", " <> boundpar <> ");\n",
 
      "  if (ierr < 0)\n",
@@ -261,7 +261,7 @@ DefFn[CreateMoLBoundariesSource[spec_] :=
       "     CCTK_ERROR(\"could not set SPEED value in table!\");\n",
 
       "\n",
-      "  ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
+      "  ierr = KrancBdy_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
       "                    \"" <> fullgroupname <> "\", \"Radiation\");\n\n",
 
       "  if (ierr < 0)\n",
@@ -295,7 +295,7 @@ DefFn[CreateMoLBoundariesSource[spec_] :=
       "      CCTK_ERROR(\"could not set SPEED value in table!\");\n",
 
       "\n",
-      "  ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
+      "  ierr = KrancBdy_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
       "                    \"" <> fullgfname <> "\", \"Radiation\");\n\n",
 
       "  if (ierr < 0)\n",
@@ -324,7 +324,7 @@ DefFn[CreateMoLBoundariesSource[spec_] :=
       "      CCTK_ERROR(\"could not set SCALAR value in table!\");\n",
 
       "\n",
-      "  ierr = Boundary_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
+      "  ierr = KrancBdy_SelectGroupForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
       "                    \"" <> fullgroupname <> "\", \"scalar\");\n\n",
 
       "  if (ierr < 0)\n",
@@ -354,7 +354,7 @@ DefFn[CreateMoLBoundariesSource[spec_] :=
       "    CCTK_ERROR(\"could not set SCALAR value in table!\");\n",
 
       "\n",
-      "  ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
+      "  ierr = KrancBdy_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, "<>myhandle<>", \n",
       "                    \"" <> fullgfname <> "\", \"scalar\");\n\n",
 
       "  if (ierr < 0)\n",
@@ -371,7 +371,7 @@ DefFn[CreateMoLBoundariesSource[spec_] :=
 
    Map[IncludeFile,
         {"cctk.h", "cctk_Arguments.h", "cctk_Parameters.h", 
-         "cctk_Faces.h", "util_Table.h", "Symmetry.h"}],
+         "cctk_Faces.h", "util_Table.h", "Symmetry.h", "Kranc.hh"}],
 
    {"\n\n",
       "/* the boundary treatment is split into 3 steps:    */\n",


### PR DESCRIPTION
This pull requests adds support for Cactus' "PreSync" functionality to Kranc. Using PreSync the Driver, Boundary thorn and flesh collaborate to use the READS / WRITES statements in the schedule to keep track of which regions of the grid are valid and, if a READS requires data that is currently invalid but can be supplied by a SYNC and / or application of boundary and symmetry conditions, will execute those before a scheduled routine starts.

To this end a thorn has to inform the driver about the boundary condition to apply to each grid variable by calling a function of the`Driver_SelectVarForBCI` before the first SYNC. This patch introduces a convenience function `Kranc_SelectVarForBCI` which combines calls to `Boundary_SelectVarForBCI` and `Driver_SelectVarForBCI`, calling the latter only if it is aliased. Depending on the value of the Cactus parameter `presync_mode` the Driver / Boundary will ignore one of the calls `Boundary_SelectVarFoBCI` or `Driver_SelectVarForBCI` without any need by the user thorn to be aware of this parameter.

Coded the way it is in this pull request a Kranc generated thorn is usable for both a flesh / Driver that do support PreSync and ones that do not.

A second change involves Kranc's built in handling of access to the stress energy tensor. In CodeGenSchedule.m (diff without whitespace: https://github.com/ianhinder/Kranc/pull/148/files?diff=split&w=1) it generates READS clauses for the grid scalar indicating storage for Tmunu which is used in Kranc's auto-generated code to skip access to Tmunu when it has no storage (see https://github.com/ianhinder/Kranc/blob/8b36a2a7243dccb9f6867d34990dd07691a0d2d0/Tools/CodeGen/CodeGenCalculation.m#L573).

These two changes make up a minimal set of modifications to fully make use of the PreSync code in the flesh.